### PR TITLE
Fix specs for IconModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
 
-## Running unit tests
+## Installing dependencies
+
+After cloning the repository, run `npm install` (or `npm ci` for automated environments) to install all dependencies. Because the `node_modules/` directory is excluded via `.gitignore`, Angular CLI commands such as `ng serve` or `npm test` will not work until the dependencies have been installed.
+
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
@@ -25,4 +28,3 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
-"# flexo-india-website-front-end" 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { IconModule } from './shared/icon/icon.module';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        IconModule
       ],
       declarations: [
         AppComponent

--- a/src/app/area-listing/area-listing.component.spec.ts
+++ b/src/app/area-listing/area-listing.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { AreaListingComponent } from './area-listing.component';
 
@@ -8,7 +9,8 @@ describe('AreaListingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ AreaListingComponent ]
+      declarations: [ AreaListingComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/booking-detail/booking-detail.component.spec.ts
+++ b/src/app/booking-detail/booking-detail.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { BookingDetailComponent } from './booking-detail.component';
 
@@ -8,7 +9,8 @@ describe('BookingDetailComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [BookingDetailComponent]
+      declarations: [BookingDetailComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(BookingDetailComponent);
     component = fixture.componentInstance;

--- a/src/app/booking-list/booking-list.component.spec.ts
+++ b/src/app/booking-list/booking-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { BookingListComponent } from './booking-list.component';
 
@@ -8,7 +9,8 @@ describe('BookingListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [BookingListComponent]
+      declarations: [BookingListComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(BookingListComponent);
     component = fixture.componentInstance;

--- a/src/app/city-listing/city-listing.component.spec.ts
+++ b/src/app/city-listing/city-listing.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { CityListingComponent } from './city-listing.component';
 
@@ -8,7 +9,8 @@ describe('CityListingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ CityListingComponent ]
+      declarations: [ CityListingComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/contact-form/contact-form.component.spec.ts
+++ b/src/app/contact-form/contact-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { ContactFormComponent } from './contact-form.component';
 
@@ -8,7 +9,8 @@ describe('ContactFormComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ContactFormComponent ]
+      declarations: [ ContactFormComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { ContactComponent } from './contact.component';
 
@@ -8,7 +9,8 @@ describe('ContactComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ContactComponent ]
+      declarations: [ ContactComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/details/buy-pass/buy-pass.component.spec.ts
+++ b/src/app/details/buy-pass/buy-pass.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../../shared/icon/icon.module';
 
 import { BuyPassComponent } from './buy-pass.component';
 
@@ -8,7 +9,8 @@ describe('BuyPassComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [BuyPassComponent]
+      declarations: [BuyPassComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(BuyPassComponent);
     component = fixture.componentInstance;

--- a/src/app/details/co-working-visit-schedule-two/co-working-visit-schedule-two.component.spec.ts
+++ b/src/app/details/co-working-visit-schedule-two/co-working-visit-schedule-two.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../../shared/icon/icon.module';
 
 import { CoWorkingVisitScheduleTwoComponent } from './co-working-visit-schedule-two.component';
 
@@ -8,7 +9,8 @@ describe('CoWorkingVisitScheduleTwoComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [CoWorkingVisitScheduleTwoComponent]
+      declarations: [CoWorkingVisitScheduleTwoComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(CoWorkingVisitScheduleTwoComponent);
     component = fixture.componentInstance;

--- a/src/app/details/co-working-visit-schedule/co-working-visit-schedule.component.spec.ts
+++ b/src/app/details/co-working-visit-schedule/co-working-visit-schedule.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../../shared/icon/icon.module';
 
 import { CoWorkingVisitScheduleComponent } from './co-working-visit-schedule.component';
 
@@ -8,7 +9,8 @@ describe('CoWorkingVisitScheduleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [CoWorkingVisitScheduleComponent]
+      declarations: [CoWorkingVisitScheduleComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(CoWorkingVisitScheduleComponent);
     component = fixture.componentInstance;

--- a/src/app/details/details.component.spec.ts
+++ b/src/app/details/details.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { DetailsComponent } from './details.component';
 
@@ -8,7 +9,8 @@ describe('DetailsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ DetailsComponent ]
+      declarations: [ DetailsComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/details/request-booking/request-booking.component.spec.ts
+++ b/src/app/details/request-booking/request-booking.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../../shared/icon/icon.module';
 
 import { RequestBookingComponent } from './request-booking.component';
 
@@ -8,7 +9,8 @@ describe('RequestBookingComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [RequestBookingComponent]
+      declarations: [RequestBookingComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(RequestBookingComponent);
     component = fixture.componentInstance;

--- a/src/app/enterprise/enterprise.component.spec.ts
+++ b/src/app/enterprise/enterprise.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { EnterpriseComponent } from './enterprise.component';
 
@@ -8,7 +9,8 @@ describe('EnterpriseComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ EnterpriseComponent ]
+      declarations: [ EnterpriseComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +9,8 @@ describe('HomeComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
+      declarations: [ HomeComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/list-with-us/list-with-us.component.spec.ts
+++ b/src/app/list-with-us/list-with-us.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { ListWithUsComponent } from './list-with-us.component';
 
@@ -8,7 +9,8 @@ describe('ListWithUsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ListWithUsComponent ]
+      declarations: [ ListWithUsComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/shared/component/filter-item/filter-item.component.spec.ts
+++ b/src/app/shared/component/filter-item/filter-item.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../../icon/icon.module';
 
 import { FilterItemComponent } from './filter-item.component';
 
@@ -8,7 +9,8 @@ describe('FilterItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [FilterItemComponent]
+      declarations: [FilterItemComponent],
+      imports: [IconModule]
     })
       .compileComponents();
   }));

--- a/src/app/shared/component/list-item/list-item.component.spec.ts
+++ b/src/app/shared/component/list-item/list-item.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IconModule } from '../../icon/icon.module';
 
 import { ListItemComponent } from './list-item.component';
 
@@ -8,7 +9,8 @@ describe('ListItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ ListItemComponent ]
+      declarations: [ ListItemComponent ],
+      imports: [IconModule]
     })
     .compileComponents();
   }));

--- a/src/app/thankyopopup/thankyopopup.component.spec.ts
+++ b/src/app/thankyopopup/thankyopopup.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconModule } from '../shared/icon/icon.module';
 
 import { ThankyopopupComponent } from './thankyopopup.component';
 
@@ -8,7 +9,8 @@ describe('ThankyopopupComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ThankyopopupComponent]
+      declarations: [ThankyopopupComponent],
+      imports: [IconModule]
     });
     fixture = TestBed.createComponent(ThankyopopupComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
## Summary
- import `IconModule` in component specs that use `<app-icon>`
- update README with `npm install` note

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684986d5d2bc8328b6d95072ba8706b9