### PR TITLE
Remove unused Zoho chat script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -145,22 +145,5 @@
 
   gtag("config", "G-9XYDZLZEMH");
 </script>
-<script type="text/javascript" id="zsiqchat">
-  var $zoho = $zoho || {};
-  $zoho.salesiq = $zoho.salesiq || {
-    widgetcode:
-      "0fc4dfe126a900d08cd66965a527bbcfebd987ea8870090a53afd7a22440aa53",
-    values: {},
-    ready: function () { },
-  };
-  var d = document;
-  s = d.createElement("script");
-  s.type = "text/javascript";
-  s.id = "zsiqscript";
-  s.defer = true;
-  s.src = "https://salesiq.zoho.in/widget";
-  t = d.getElementsByTagName("script")[0];
-  t.parentNode.insertBefore(s, t);
-</script>
 
 </html>


### PR DESCRIPTION
## Summary
- remove `zsiqchat` script tag from `index.html`
- ensure dynamic loading for Google Maps remains unchanged

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*
- `npx ng build`

------
https://chatgpt.com/codex/tasks/task_e_68498d4b1680832898a6e793de62cc63