### PR TITLE
Enable Quicklink preloading and deferrable views

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy
 import { MatStepperModule } from '@angular/material/stepper';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
+import { QuicklinkModule, QuicklinkStrategy } from 'ngx-quicklink';
 
 import { DatePipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
@@ -121,9 +122,11 @@ export function loadGoogleMaps(): () => Promise<void> {
     NgxIntlTelInputModule,
     NgxJsonLdModule,
     SharedModule,
+    QuicklinkModule,
     RouterModule.forRoot(routes, {
       initialNavigation: 'enabledBlocking',
-      scrollPositionRestoration: 'enabled'
+      scrollPositionRestoration: 'enabled',
+      preloadingStrategy: QuicklinkStrategy
     }),
     NgSelectModule,
     NgxSliderModule,

--- a/src/app/details/details.component.html
+++ b/src/app/details/details.component.html
@@ -739,10 +739,15 @@
 
           <div id="location" class="list-details-section">
             <h2 class="location-section fs-20">Location</h2>
-            <google-map height="400px" width="100%" [zoom]="15" [center]="marker?.position">
-              <!-- <map-circle [center]="marker?.position" [radius]="circleRadius1" [options]="circleOptions1"></map-circle> -->
-              <map-circle [center]="marker?.position" [radius]="circleRadius2" [options]="circleOptions2"></map-circle>
-            </google-map><br />
+            @defer (on viewport) {
+              <google-map height="400px" width="100%" [zoom]="15" [center]="marker?.position">
+                <!-- <map-circle [center]="marker?.position" [radius]="circleRadius1" [options]="circleOptions1"></map-circle> -->
+                <map-circle [center]="marker?.position" [radius]="circleRadius2" [options]="circleOptions2"></map-circle>
+              </google-map>
+            } @placeholder {
+              <div style="height:400px;width:100%;background:#f0f0f0"></div>
+            }
+            <br />
             <div class="commute-details" style="justify-content: flex-end">
               <div class="commute-details-item">
                 <div class="commute-label">

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -894,8 +894,9 @@
       <div class="col-md-12">
         <div class="swiper-container popular-place-wrap v2">
           <div class="swiper-wrapper">
-            <ngx-slick-carousel class="carousel" #slickReviewsModal="slick-carousel" [config]="reviewsConfig"
-              responsive="breakpoints">
+            @defer (on viewport) {
+              <ngx-slick-carousel class="carousel" #slickReviewsModal="slick-carousel" [config]="reviewsConfig"
+                responsive="breakpoints">
               <div ngxSlickItem class="swiper-slide popular-item slide">
                 <div class="single-place">
                   <img class="single-place-image" src="https://flexospaces-images.s3.ap-south-1.amazonaws.com/img/category/Andheri-East.jpg" alt="place-image" />
@@ -976,6 +977,9 @@
                 </div>
               </div>
             </ngx-slick-carousel>
+            } @placeholder {
+              <div style="height:200px;width:100%;background:#f0f0f0"></div>
+            }
           </div>
         </div>
         <div class="slider-btn v1 popular-next style2" (click)="next()">


### PR DESCRIPTION
## Summary
- use Quicklink preloading strategy to load modules when links enter viewport
- defer Google Map rendering in the details page until the section is visible
- defer home page location carousel until scrolled into view

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb72f94c832893f52fe145bafedf