### PR TITLE
Lazy load intl-tel-input

### DIFF
--- a/src/app/details/inquiry/inquiry.component.ts
+++ b/src/app/details/inquiry/inquiry.component.ts
@@ -6,7 +6,6 @@ import {
   MatLegacyDialogRef as MatDialogRef
 } from '@angular/material/legacy-dialog';
 import { ActivatedRoute, ParamMap } from '@angular/router';
-import intlTelInput from 'intl-tel-input';
 import { CountryISO } from 'ngx-intl-tel-input';
 import { ToastrService } from 'ngx-toastr';
 import { SpaceService } from 'src/app/services/space.service';
@@ -39,7 +38,7 @@ export class InquiryComponent {
   isOpen: boolean = true;
   userId: any;
   public ref: any;
-  iti: any = intlTelInput;
+  iti: import('intl-tel-input').Iti;
   CountryISO = CountryISO;
   selectedCountryData: any;
   dialCode: any;
@@ -117,6 +116,9 @@ export class InquiryComponent {
   ngOnInit(): void {
     this.formData.spaceType = this.data.name ?? "";
     if (isPlatformBrowser(this.platformId)) {
+      import('intl-tel-input').then(({ default: intlTelInput }) => {
+        this.iti = intlTelInput as any;
+      });
       this.isCoworkings = sessionStorage.getItem('isCoworking');
       this.valueForListingPage = localStorage.getItem('staticValue');
     }

--- a/src/app/login/login-dialog.component.ts
+++ b/src/app/login/login-dialog.component.ts
@@ -25,7 +25,6 @@ import {
   SocialAuthService,
   SocialUser,
 } from '@abacritt/angularx-social-login';
-import intlTelInput from 'intl-tel-input';
 import { Subscription } from 'rxjs/internal/Subscription';
 import { timer } from 'rxjs/internal/observable/timer';
 import { take } from 'rxjs/operators';
@@ -179,59 +178,61 @@ export class LoginDialog implements OnInit {
 
   private initializeIntlTelInput(): void {
     if (isPlatformBrowser(this.platformId)) {
-      const input = document.querySelector("#tel") as HTMLInputElement;
+      import('intl-tel-input').then(({ default: intlTelInput }) => {
+        const input = document.querySelector("#tel") as HTMLInputElement;
 
-      if (input && !this.itiInitialized) {
-        this.iti = intlTelInput(input, {
-          initialCountry: "auto",
-          geoIpLookup: function (success, failure) {
-            fetch('https://ipinfo.io')
-              .then(response => response.json())
-              .then(data => success(data.country))
-              .catch(() => success('IN'));
-          },
-          utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
-        });
+        if (input && !this.itiInitialized) {
+          this.iti = intlTelInput(input, {
+            initialCountry: "auto",
+            geoIpLookup: function (success, failure) {
+              fetch('https://ipinfo.io')
+                .then(response => response.json())
+                .then(data => success(data.country))
+                .catch(() => success('IN'));
+            },
+            utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
+          });
 
-        input.addEventListener("countrychange", () => this.onCountryChange2(this.iti));
-        this.itiInitialized = true;
-      }
+          input.addEventListener("countrychange", () => this.onCountryChange2(this.iti));
+          this.itiInitialized = true;
+        }
 
-      const input2 = document.querySelector("#tel2") as HTMLInputElement;
+        const input2 = document.querySelector("#tel2") as HTMLInputElement;
 
-      if (input2 && !this.iti2Initialized) {
-        this.iti2 = intlTelInput(input2, {
-          initialCountry: "auto",
-          geoIpLookup: function (success, failure) {
-            fetch('https://ipinfo.io')
-              .then(response => response.json())
-              .then(data => success(data.country))
-              .catch(() => success('IN'));
-          },
-          utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
-        });
+        if (input2 && !this.iti2Initialized) {
+          this.iti2 = intlTelInput(input2, {
+            initialCountry: "auto",
+            geoIpLookup: function (success, failure) {
+              fetch('https://ipinfo.io')
+                .then(response => response.json())
+                .then(data => success(data.country))
+                .catch(() => success('IN'));
+            },
+            utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
+          });
 
-        input2.addEventListener("countrychange", () => this.onCountryChange2(this.iti2));
-        this.iti2Initialized = true;
-      }
+          input2.addEventListener("countrychange", () => this.onCountryChange2(this.iti2));
+          this.iti2Initialized = true;
+        }
 
-      const input3 = document.querySelector("#tel3") as HTMLInputElement;
+        const input3 = document.querySelector("#tel3") as HTMLInputElement;
 
-      if (input3 && !this.iti3Initialized) {
-        this.iti3 = intlTelInput(input3, {
-          initialCountry: "auto",
-          geoIpLookup: function (success, failure) {
-            fetch('https://ipinfo.io')
-              .then(response => response.json())
-              .then(data => success(data.country))
-              .catch(() => success('IN'));
-          },
-          utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
-        });
+        if (input3 && !this.iti3Initialized) {
+          this.iti3 = intlTelInput(input3, {
+            initialCountry: "auto",
+            geoIpLookup: function (success, failure) {
+              fetch('https://ipinfo.io')
+                .then(response => response.json())
+                .then(data => success(data.country))
+                .catch(() => success('IN'));
+            },
+            utilsScript: 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js'
+          });
 
-        input3.addEventListener("countrychange", () => this.onCountryChange2(this.iti3));
-        this.iti3Initialized = true;
-      }
+          input3.addEventListener("countrychange", () => this.onCountryChange2(this.iti3));
+          this.iti3Initialized = true;
+        }
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- load `intl-tel-input` dynamically in login dialog
- lazy import `intl-tel-input` in inquiry component

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685901556a4083288689f9f75fe8ca5b