### PR TITLE
Add module imports to spec files

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { AboutComponent } from './about.component';
 
@@ -8,6 +12,7 @@ describe('AboutComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ AboutComponent ]
     })
     .compileComponents();

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
+import { MaterialModule } from 'material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from 'shared/shared/shared.module';
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {

--- a/src/app/area-listing/area-listing.component.spec.ts
+++ b/src/app/area-listing/area-listing.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { AreaListingComponent } from './area-listing.component';
 
@@ -8,6 +12,7 @@ describe('AreaListingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ AreaListingComponent ]
     })
     .compileComponents();

--- a/src/app/booking-detail/booking-detail.component.spec.ts
+++ b/src/app/booking-detail/booking-detail.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { BookingDetailComponent } from './booking-detail.component';
 
@@ -8,6 +12,7 @@ describe('BookingDetailComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [BookingDetailComponent]
     });
     fixture = TestBed.createComponent(BookingDetailComponent);

--- a/src/app/booking-list/booking-list.component.spec.ts
+++ b/src/app/booking-list/booking-list.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { BookingListComponent } from './booking-list.component';
 
@@ -8,6 +12,7 @@ describe('BookingListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [BookingListComponent]
     });
     fixture = TestBed.createComponent(BookingListComponent);

--- a/src/app/careers/careers.component.spec.ts
+++ b/src/app/careers/careers.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { CareersComponent } from './careers.component';
 
@@ -8,6 +12,7 @@ describe('CareersComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ CareersComponent ]
     })
     .compileComponents();

--- a/src/app/city-listing/city-listing.component.spec.ts
+++ b/src/app/city-listing/city-listing.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { CityListingComponent } from './city-listing.component';
 
@@ -8,6 +12,7 @@ describe('CityListingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ CityListingComponent ]
     })
     .compileComponents();

--- a/src/app/contact-form/contact-form.component.spec.ts
+++ b/src/app/contact-form/contact-form.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { ContactFormComponent } from './contact-form.component';
 
@@ -8,6 +12,7 @@ describe('ContactFormComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ ContactFormComponent ]
     })
     .compileComponents();

--- a/src/app/contact/contact.component.spec.ts
+++ b/src/app/contact/contact.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { ContactComponent } from './contact.component';
 
@@ -8,6 +12,7 @@ describe('ContactComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ ContactComponent ]
     })
     .compileComponents();

--- a/src/app/details/add-review-dialog/add-review-dialog.component.spec.ts
+++ b/src/app/details/add-review-dialog/add-review-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared/shared.module';
 
 import { AddReviewDialogComponent } from './add-review-dialog.component';
 
@@ -8,6 +12,7 @@ describe('AddReviewDialogComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [AddReviewDialogComponent]
     });
     fixture = TestBed.createComponent(AddReviewDialogComponent);

--- a/src/app/details/buy-pass/buy-pass.component.spec.ts
+++ b/src/app/details/buy-pass/buy-pass.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared/shared.module';
 
 import { BuyPassComponent } from './buy-pass.component';
 
@@ -8,6 +12,7 @@ describe('BuyPassComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [BuyPassComponent]
     });
     fixture = TestBed.createComponent(BuyPassComponent);

--- a/src/app/details/co-working-visit-schedule-two/co-working-visit-schedule-two.component.spec.ts
+++ b/src/app/details/co-working-visit-schedule-two/co-working-visit-schedule-two.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared/shared.module';
 
 import { CoWorkingVisitScheduleTwoComponent } from './co-working-visit-schedule-two.component';
 
@@ -8,6 +12,7 @@ describe('CoWorkingVisitScheduleTwoComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [CoWorkingVisitScheduleTwoComponent]
     });
     fixture = TestBed.createComponent(CoWorkingVisitScheduleTwoComponent);

--- a/src/app/details/co-working-visit-schedule/co-working-visit-schedule.component.spec.ts
+++ b/src/app/details/co-working-visit-schedule/co-working-visit-schedule.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared/shared.module';
 
 import { CoWorkingVisitScheduleComponent } from './co-working-visit-schedule.component';
 
@@ -8,6 +12,7 @@ describe('CoWorkingVisitScheduleComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [CoWorkingVisitScheduleComponent]
     });
     fixture = TestBed.createComponent(CoWorkingVisitScheduleComponent);

--- a/src/app/details/details.component.spec.ts
+++ b/src/app/details/details.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { DetailsComponent } from './details.component';
 
@@ -8,6 +12,7 @@ describe('DetailsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ DetailsComponent ]
     })
     .compileComponents();

--- a/src/app/details/request-booking/request-booking.component.spec.ts
+++ b/src/app/details/request-booking/request-booking.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared/shared.module';
 
 import { RequestBookingComponent } from './request-booking.component';
 
@@ -8,6 +12,7 @@ describe('RequestBookingComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [RequestBookingComponent]
     });
     fixture = TestBed.createComponent(RequestBookingComponent);

--- a/src/app/enterprise/enterprise.component.spec.ts
+++ b/src/app/enterprise/enterprise.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { EnterpriseComponent } from './enterprise.component';
 
@@ -8,6 +12,7 @@ describe('EnterpriseComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ EnterpriseComponent ]
     })
     .compileComponents();

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { HomeComponent } from './home.component';
 
@@ -8,6 +12,7 @@ describe('HomeComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ HomeComponent ]
     })
     .compileComponents();

--- a/src/app/joy-of-giving/joy-of-giving.component.spec.ts
+++ b/src/app/joy-of-giving/joy-of-giving.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { JoyOfGivingComponent } from './joy-of-giving.component';
 
@@ -8,6 +12,7 @@ describe('JoyOfGivingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ JoyOfGivingComponent ]
     })
     .compileComponents();

--- a/src/app/list-with-us/list-with-us.component.spec.ts
+++ b/src/app/list-with-us/list-with-us.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { ListWithUsComponent } from './list-with-us.component';
 
@@ -8,6 +12,7 @@ describe('ListWithUsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ ListWithUsComponent ]
     })
     .compileComponents();

--- a/src/app/payments/payments.component.spec.ts
+++ b/src/app/payments/payments.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { PaymentsComponent } from './payments.component';
 
@@ -8,6 +12,7 @@ describe('PaymentsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [PaymentsComponent]
     });
     fixture = TestBed.createComponent(PaymentsComponent);

--- a/src/app/privacy-policy/privacy-policy.component.spec.ts
+++ b/src/app/privacy-policy/privacy-policy.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { PrivacyPolicyComponent } from './privacy-policy.component';
 
@@ -8,6 +12,7 @@ describe('PrivacyPolicyComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ PrivacyPolicyComponent ]
     })
     .compileComponents();

--- a/src/app/refund-policy/refund-policy.component.spec.ts
+++ b/src/app/refund-policy/refund-policy.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { RefundPolicyComponent } from './refund-policy.component';
 
@@ -8,6 +12,7 @@ describe('RefundPolicyComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [RefundPolicyComponent]
     });
     fixture = TestBed.createComponent(RefundPolicyComponent);

--- a/src/app/shared/component/filter-item/filter-item.component.spec.ts
+++ b/src/app/shared/component/filter-item/filter-item.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared.module';
 
 import { FilterItemComponent } from './filter-item.component';
 
@@ -8,6 +12,7 @@ describe('FilterItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [FilterItemComponent]
     })
       .compileComponents();

--- a/src/app/shared/component/list-item/list-item.component.spec.ts
+++ b/src/app/shared/component/list-item/list-item.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared.module';
 
 import { ListItemComponent } from './list-item.component';
 
@@ -8,6 +12,7 @@ describe('ListItemComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ ListItemComponent ]
     })
     .compileComponents();

--- a/src/app/shared/component/shimmer-loading/shimmer-loading.component.spec.ts
+++ b/src/app/shared/component/shimmer-loading/shimmer-loading.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../../shared/shared.module';
 
 import { ShimmerLoadingComponent } from './shimmer-loading.component';
 

--- a/src/app/shared/icon/icon.component.spec.ts
+++ b/src/app/shared/icon/icon.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared.module';
 
 import { IconComponent } from './icon.component';
 
@@ -8,6 +12,7 @@ describe('IconComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [IconComponent]
     });
     fixture = TestBed.createComponent(IconComponent);

--- a/src/app/shared/shared/_404/_404.component.spec.ts
+++ b/src/app/shared/shared/_404/_404.component.spec.ts
@@ -2,6 +2,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { MaterialModule } from '../../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared.module';
 
 import { _404Component } from './_404.component';
 
@@ -11,6 +15,7 @@ describe('_404Component', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ _404Component ]
     })
     .compileComponents();

--- a/src/app/shared/shared/faqs/faqs.component.spec.ts
+++ b/src/app/shared/shared/faqs/faqs.component.spec.ts
@@ -2,6 +2,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { MaterialModule } from '../../../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared.module';
 
 import { FaqsComponent } from './faqs.component';
 
@@ -11,6 +15,7 @@ describe('FaqsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ FaqsComponent ]
     })
     .compileComponents();

--- a/src/app/shortlisted-spaces/shortlisted-spaces.component.spec.ts
+++ b/src/app/shortlisted-spaces/shortlisted-spaces.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { ShortlistedSpacesComponent } from './shortlisted-spaces.component';
 
@@ -8,6 +12,7 @@ describe('ShortlistedSpacesComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ShortlistedSpacesComponent]
     })
       .compileComponents();

--- a/src/app/terms-conditions/terms-conditions.component.spec.ts
+++ b/src/app/terms-conditions/terms-conditions.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { TermsConditionsComponent } from './terms-conditions.component';
 
@@ -8,6 +12,7 @@ describe('TermsConditionsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ TermsConditionsComponent ]
     })
     .compileComponents();

--- a/src/app/thankyopopup/thankyopopup.component.spec.ts
+++ b/src/app/thankyopopup/thankyopopup.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../material.module';
+import { SlickCarouselModule } from 'ngx-slick-carousel';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared/shared.module';
 
 import { ThankyopopupComponent } from './thankyopopup.component';
 
@@ -8,6 +12,7 @@ describe('ThankyopopupComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, SlickCarouselModule, ReactiveFormsModule, FormsModule, SharedModule],
       declarations: [ThankyopopupComponent]
     });
     fixture = TestBed.createComponent(ThankyopopupComponent);


### PR DESCRIPTION
## Summary
- import necessary Angular modules in component spec files
- include modules in `configureTestingModule` for tests

## Testing
- `npm install --legacy-peer-deps --no-progress` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68590a06f91c83288a732269033f6cb4